### PR TITLE
API example of deleting a policy in the API docs

### DIFF
--- a/modify_policies/modify_policies.py
+++ b/modify_policies/modify_policies.py
@@ -9,7 +9,7 @@ if len(sys.argv) != 4:
     print "Usage: python modify_policies.py [account_hash] [host_hash] [scope_id]"
     sys.exit()
 PARENT_ACCOUNT = sys.argv[1]
-HOST = sys.argv[2] # Friendly name for host in StrikeTracker
+HOST = sys.argv[2] # Host hash
 SCOPE_ID = sys.argv[3] # Scope id which you want to edit
 OAUTH_TOKEN = os.environ['STRIKETRACKER_TOKEN']
 

--- a/modify_policies/modify_policies.py
+++ b/modify_policies/modify_policies.py
@@ -35,7 +35,7 @@ host = host_response.json()
 json.dump(host, sys.stdout, indent=4, separators=(',', ': '))
 print ""
 
-# Delete dynamicContent policy
+# Delete compression policy
 host_response = requests.put(
     STRIKETRACKER_URL + "/api/accounts/{accountHash}/hosts/{host}/configuration/{scope}".format(
         accountHash=PARENT_ACCOUNT,

--- a/modify_policies/modify_policies.py
+++ b/modify_policies/modify_policies.py
@@ -1,0 +1,51 @@
+import getpass
+import requests
+import os
+import sys
+import json
+
+STRIKETRACKER_URL = os.environ['STRIKETRACKER_URL'] if 'STRIKETRACKER_URL' in os.environ else 'https://striketracker.highwinds.com'
+if len(sys.argv) != 4:
+    print "Usage: python modify_policies.py [account_hash] [host_hash] [scope_id]"
+    sys.exit()
+PARENT_ACCOUNT = sys.argv[1]
+HOST = sys.argv[2] # Friendly name for host in StrikeTracker
+SCOPE_ID = sys.argv[3] # Scope id which you want to edit
+OAUTH_TOKEN = os.environ['STRIKETRACKER_TOKEN']
+
+configuration = {
+    "dynamicContent": {
+        "queryParams": "start,end"
+    },
+    "compression": {
+        "gzip": "css,html"
+    }
+}
+
+# Add policies
+host_response = requests.put(
+    STRIKETRACKER_URL + "/api/accounts/{accountHash}/hosts/{host}/configuration/{scope}".format(
+        accountHash=PARENT_ACCOUNT,
+        host=HOST,
+        scope=SCOPE_ID
+    ),
+    headers={"Authorization": "Bearer %s" % OAUTH_TOKEN, "Content-Type": "application/json"},
+    data=json.dumps(configuration))
+host = host_response.json()
+json.dump(host, sys.stdout, indent=4, separators=(',', ': '))
+print ""
+
+# Delete dynamicContent policy
+host_response = requests.put(
+    STRIKETRACKER_URL + "/api/accounts/{accountHash}/hosts/{host}/configuration/{scope}".format(
+        accountHash=PARENT_ACCOUNT,
+        host=HOST,
+        scope=SCOPE_ID
+    ),
+    headers={"Authorization": "Bearer %s" % OAUTH_TOKEN, "Content-Type": "application/json"},
+    data=json.dumps({
+        "compression": {}
+    }))
+host = host_response.json()
+json.dump(host, sys.stdout, indent=4, separators=(',', ': '))
+print ""


### PR DESCRIPTION
This example shows API customers how to add and delete policies on a configuration scope.